### PR TITLE
feat: Support GTM debug

### DIFF
--- a/integrations/GTAG.tsx
+++ b/integrations/GTAG.tsx
@@ -1,38 +1,46 @@
-import { Head } from "$fresh/runtime.ts";
-
 import Script from "../Script.tsx";
 
 interface Props {
   trackingId: string;
 }
 
-const snippet = (trackingId: string) => `
-// It is safe to .push in datalayer in here because partytown have already
-// run and made dataLayer.push available in window
-window.gtag = window.gtag || function(){window.dataLayer.push(arguments)};
+declare global {
+  interface Window {
+    gtag: (...args: unknown[]) => void
+  }
+}
 
-function init() {
-  window.gtag("js", new Date());
-  window.gtag("config", "${trackingId}");
-};
+function snippet(trackingId: string) {
+  // It is safe to .push in datalayer in here because partytown have already
+  // run and made dataLayer.push available in window
+  window.gtag = window.gtag || function () {
+    window.dataLayer.push(arguments);
+  };
 
-if (document.readyState === 'complete') {
-  init();
-} else {
-  window.addEventListener('load', init);
-};
-`;
+  function init() {
+    window.gtag("js", new Date());
+    window.gtag("config", trackingId);
+  }
+
+  if (document.readyState === "complete") {
+    init();
+  } else {
+    addEventListener("load", init);
+  }
+}
 
 const GoogleTagManager = ({ trackingId = "" }: Props) => (
   <>
     <Script
+      id={`gtag-script-${trackingId}`}
       forward={["dataLayer.push"]}
       src={`https://www.googletagmanager.com/gtag/js?id=${trackingId}`}
     />
     <Script
-      type="application/javascript"
+      id={`gtag-script-global-${trackingId}`}
+      type="module"
       dangerouslySetInnerHTML={{
-        __html: snippet(trackingId),
+        __html: `(${snippet})(${trackingId});`,
       }}
     />
   </>

--- a/integrations/GTM.tsx
+++ b/integrations/GTM.tsx
@@ -4,31 +4,43 @@ interface Props {
   trackingId: string;
 }
 
-const snippet = () => `
-// It is safe to .push in datalayer in here because partytown have already
-// run and made dataLayer.push available in window
-function init() {
-  window.dataLayer.push({'gtm.start':new Date().getTime(), event:'gtm.js'});
+declare global {
+  interface Window {
+    dataLayer: unknown[];
+  }
 }
 
-if (document.readyState === 'complete') {
-  init();
-} else {
-  window.addEventListener('load', init);
-};
-          
-`;
+function snippet() {
+  window.dataLayer = window.dataLayer || [];
+
+  // It is safe to .push in datalayer in here because partytown have already
+  // run and made dataLayer.push available in window
+  function init() {
+    window.dataLayer.push({
+      "gtm.start": new Date().getTime(),
+      event: "gtm.js",
+    });
+  }
+
+  if (document.readyState === "complete") {
+    init();
+  } else {
+    addEventListener("load", init);
+  }
+}
 
 const GoogleTagManager = ({ trackingId = "" }: Props) => (
   <>
     <Script
+      id={`gtm-script-${trackingId}`}
       forward={["dataLayer.push"]}
       src={`https://www.googletagmanager.com/gtm.js?id=${trackingId}`}
     />
     <Script
-      type="application/javascript"
+      id={`gtm-script-global-${trackingId}`}
+      type="module"
       dangerouslySetInnerHTML={{
-        __html: snippet(),
+        __html: `(${snippet})();`,
       }}
     />
   </>

--- a/integrations/Jitsu.tsx
+++ b/integrations/Jitsu.tsx
@@ -7,17 +7,33 @@ interface Props extends ComponentProps<typeof Script> {
   "data-init-only"?: "true" | "false";
 }
 
+declare global {
+  interface Window {
+    jitsu: (...args: unknown[]) => void;
+    jitsuQ: unknown[];
+  }
+}
+
+function snippet() {
+  window.jitsu = window.jitsu || (function () {
+    (window.jitsuQ = window.jitsuQ || []).push(arguments);
+  });
+}
+
 const Jitsu = (props: Props) => (
   <>
     <Script
-      id="jitsu-script"
+      id={`jitsu-script-${props["data-key"]}`}
       forward={["jitsu"]}
       src="https://t.jitsu.com/s/lib.js"
       {...props}
     />
     {/* Jitsu Doc snippet */}
-    <Script id="jitsu-script-global">
-      {`window.jitsu = window.jitsu || (function(){(window.jitsuQ = window.jitsuQ || []).push(arguments);})`}
+    <Script
+      id={`jitsu-script-global-${props["data-key"]}`}
+      type="module"
+      dangerouslySetInnerHTML={{ __html: `(${snippet})();` }}
+    >
     </Script>
   </>
 );

--- a/shared.ts
+++ b/shared.ts
@@ -2,8 +2,10 @@ declare namespace globalThis {
   let __partytownGlobalOptionsStorage: { forward: string[] };
 }
 
-globalThis.__partytownGlobalOptionsStorage = {
-  forward: [],
+export const clearForward = () => {
+  globalThis.__partytownGlobalOptionsStorage = {
+    forward: [],
+  };
 };
 
 export const collectForward = (forward: string[]) => {
@@ -22,3 +24,5 @@ export const readForward = () => {
     forward,
   };
 };
+
+clearForward();


### PR DESCRIPTION
## What's the purpose of this PR?
This PR allows disabling partytown by running scripts on main thread. With this, GTM debug console works just fine.

## Usage
Add the querystring `disablePartytown` or `gtm_debug` to your website. This will trigger a script that changes all `text/partytown` scripts into `text/javascript`, disabling partytown and making the scripts run as usual.

Add the querystring `debugPartytown` to pass the debug option to partytown. 