### PR TITLE
fix: iframe errors

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -92,7 +92,12 @@ const partytown = (
         }
         return url;
       };
-      ${partytownSnippet()}
+      
+      if (window === top) {
+        ${partytownSnippet()}
+      } else {
+        console.info("Partytown snippet not laoded due to being inside an iframe");
+      }
     }`,
     },
     render(ctx) {


### PR DESCRIPTION
This PR fixes the following issue when running it inside an iframe:

<img width="602" alt="image" src="https://github.com/deco-cx/partytown/assets/1753396/50839d5e-2da3-4c75-9d04-2fcdcda72bd3">
