### PR TITLE
feat: Add `preventCollect` to prevent forward `dataLayer.push` to partytown

### DIFF
--- a/integrations/GTAG.tsx
+++ b/integrations/GTAG.tsx
@@ -3,6 +3,10 @@ import Script from "../Script.tsx";
 interface Props {
   trackingId: string;
   dangerouslyRunOnMainThread?: boolean;
+  /**
+   * @description prevent forward to partytown
+   */
+  preventCollect?: boolean;
 }
 
 declare global {
@@ -21,7 +25,8 @@ function snippet(trackingId: string) {
 }
 
 const GoogleTagManager = (
-  { trackingId = "", dangerouslyRunOnMainThread = false }: Props,
+  { trackingId = "", dangerouslyRunOnMainThread = false, preventCollect }:
+    Props,
 ) => {
   const type = dangerouslyRunOnMainThread
     ? "text/javascript"
@@ -31,7 +36,9 @@ const GoogleTagManager = (
     <>
       <Script
         id={`gtag-script-${trackingId}`}
-        forward={["dataLayer.push"]}
+        forward={dangerouslyRunOnMainThread || preventCollect
+          ? undefined
+          : ["dataLayer.push"]}
         type={type}
         async={dangerouslyRunOnMainThread ? true : undefined}
         src={`https://www.googletagmanager.com/gtag/js?id=${trackingId}`}

--- a/integrations/GTAG.tsx
+++ b/integrations/GTAG.tsx
@@ -6,7 +6,7 @@ interface Props {
   /**
    * @description prevent forward to partytown
    */
-  preventCollect?: boolean;
+  preventForward?: boolean;
 }
 
 declare global {
@@ -25,7 +25,7 @@ function snippet(trackingId: string) {
 }
 
 const GoogleTagManager = (
-  { trackingId = "", dangerouslyRunOnMainThread = false, preventCollect }:
+  { trackingId = "", dangerouslyRunOnMainThread = false, preventForward }:
     Props,
 ) => {
   const type = dangerouslyRunOnMainThread
@@ -36,7 +36,7 @@ const GoogleTagManager = (
     <>
       <Script
         id={`gtag-script-${trackingId}`}
-        forward={dangerouslyRunOnMainThread || preventCollect
+        forward={dangerouslyRunOnMainThread || preventForward
           ? undefined
           : ["dataLayer.push"]}
         type={type}

--- a/integrations/GTM.tsx
+++ b/integrations/GTM.tsx
@@ -13,7 +13,7 @@ type Props = (Hosted | OnPremises) & {
   /**
    * @description prevent forward to partytown
    */
-  preventCollect?: boolean;
+  preventForward?: boolean;
 };
 
 declare global {
@@ -51,7 +51,7 @@ const GoogleTagManager = (props: Props) => {
         id={`gtm-script-${id}`}
         type={type}
         async={props.dangerouslyRunOnMainThread ? true : undefined}
-        forward={props.dangerouslyRunOnMainThread || props.preventCollect
+        forward={props.dangerouslyRunOnMainThread || props.preventForward
           ? undefined
           : ["dataLayer.push"]}
         src={src}

--- a/integrations/GTM.tsx
+++ b/integrations/GTM.tsx
@@ -10,6 +10,10 @@ interface OnPremises {
 
 type Props = (Hosted | OnPremises) & {
   dangerouslyRunOnMainThread?: boolean;
+  /**
+   * @description prevent forward to partytown
+   */
+  preventCollect?: boolean;
 };
 
 declare global {
@@ -47,7 +51,9 @@ const GoogleTagManager = (props: Props) => {
         id={`gtm-script-${id}`}
         type={type}
         async={props.dangerouslyRunOnMainThread ? true : undefined}
-        forward={["dataLayer.push"]}
+        forward={props.dangerouslyRunOnMainThread || props.preventCollect
+          ? undefined
+          : ["dataLayer.push"]}
         src={src}
       />
       <Script


### PR DESCRIPTION
### Issue
Today, is it possible to use two GTM components in the same page one in the main thread and other inside the partytown, but booth is proxying the `dataLayer.push` variable, creating an issue with the GTM Script on the main thread that can't access the dataLayer because partytown proxy.

### Solution
prevent `forward` the `dataLayer.push` with a prop.